### PR TITLE
v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v1.4.1 (2026-03-29)
+
+### Bug fixes
+- Fixed crash with matrix-valued GreenFunctions (e.g. `GreenFunction(zeros(ComplexF64, 2, 2, 1, 1), SkewHermitian)`) on RecursiveArrayTools v3: `VectorOfArray[i, :]` now returns collapsed arrays, so `extend!` accesses `.u` directly to preserve element types
+
+### Tests
+- Added fermionic dimer test (2-site tight-binding with exact matrix exponential solution)
+- Added Ornstein-Uhlenbeck (Brownian motion) test with closed-form analytical solution
+- Added geometric Brownian motion test with coupled nonlinear dynamics
+- Added Bose-Einstein condensate test with mixed OnePoint/SkewHermitian evolution
+- Test count increased from 27 to 32
+
+### Other
+- Minimum Julia raised to 1.12
+- Added list of 21 papers citing the SciPost publication to README and docs
+- Added stable docs, version, and license badges to README
+
 ## v1.4.0 (2026-03-29)
 
 ### Infrastructure

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KadanoffBaym"
 uuid = "82532805-809c-4ef0-842b-4b00c5e9be5f"
 authors = ["Francisco Meirinhos, Tim Bode"]
-version = "1.4.0"
+version = "1.4.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"


### PR DESCRIPTION
## Summary

Patch release with a bug fix, new tests, and Julia 1.12 support.

- **Bug fix**: matrix-valued GreenFunctions crashed on RecursiveArrayTools v3 (#31)
- **Tests**: 27 → 32 tests (fermionic dimer, Brownian motion, geometric Brownian motion, BEC)
- **Julia 1.12**: minimum version raised from 1.10 to 1.12

See [CHANGELOG.md](https://github.com/NonequilibriumDynamics/KadanoffBaym.jl/blob/v1.4.1/CHANGELOG.md) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)